### PR TITLE
Fix : Download GEI CLI to fix './gei' is not recognized as a name of a cmdlet error

### DIFF
--- a/.github/workflows/manual-migration.yml
+++ b/.github/workflows/manual-migration.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Download GEI CLI
+        run: |
+          curl -L -o gei https://github.com/github/gh-gei/releases/latest/download/gei-linux-amd64
+          chmod +x gei
+
       - name: Migrate repository
         shell: pwsh
         env:


### PR DESCRIPTION
The term './gei' is not recognized as a name of a cmdlet, function,
       | script file, or executable program. Check the spelling of the name, or
       | if a path was included, verify that the path is correct and try again.

So download GEI CLI to fix this issue